### PR TITLE
Add slang support based on ruoso++'s Grammar::EBNF work

### DIFF
--- a/lib/Grammar/BNF.pm
+++ b/lib/Grammar/BNF.pm
@@ -5,6 +5,11 @@ grammar Grammar::BNF {
         \s* <rule>+ \s*
     }
 
+    # Apparently when used for slang we need a lowercase top rule?
+    token main_syntax {
+        <TOP>
+    }
+
     token rule {
         <opt-ws> '<' <rule-name> '>' <opt-ws> '::=' <opt-ws> <expression> <line-end>
     }
@@ -37,23 +42,39 @@ grammar Grammar::BNF {
         '"' <-["]>* '"' | "'" <-[']>* "'"
     }
 
-    method generate($source, :$name = 'BNFGrammar') {
-        my $actions = Actions.new(:$name);
-        my $ret = self.new.parse($source, :$actions).ast;
-        return $ret.WHAT;
+    # Provide a parse with defaults and also define our per-parse scope.
+    method parse(|c) {
+        my $*name = c<name> // 'BNFGrammar';
+        nextsame if (c<actions>);
+        nextwith(|c, :actions(Actions));
+    }
+
+    # We may want to rename this given jnthn's Grammar::Generative
+    method generate(|c) {
+        my $res = self.parse(|c);
+        fail("parse *of* an BNF grammar definition failed.") unless $res;
+	return $res.ast;
     }
 }
 
 my class Actions {
-    has $.name = 'BNFGrammar';
-    method TOP($/) {
-        my $grmr := Metamodel::GrammarHOW.new_type(:$.name);
-        $grmr.^add_method('TOP', EVAL 'token { <' ~ $<rule>[0].ast.key ~ '> }');
-        for $<rule>.map(*.ast) -> $rule {
+
+    my sub guts($/, $rule) {
+	# Note: $*name can come from .parse above or from Slang::BNF
+        my $grmr := Metamodel::GrammarHOW.new_type(:name($*name));
+        $grmr.^add_method('TOP', EVAL 'token { <' ~ $rule[0].ast.key ~ '> }');
+        for $rule.map(*.ast) -> $rule {
             $grmr.^add_method($rule.key, $rule.value);
         }
         $grmr.^compose;
-        make $grmr;
+    }
+
+    method TOP($/) {
+        make guts($/, $<rule>);
+    }
+
+    method main_syntax($/) {
+        make guts($/, $<TOP><rule>);
     }
 
     method rule($/) {
@@ -80,3 +101,6 @@ my class Actions {
         make ~$/;
     }
 }
+
+# For the slang guts we need an actions class we can find.
+class Grammar::BNF-actions is Actions { };

--- a/lib/Slang/BNF.pm
+++ b/lib/Slang/BNF.pm
@@ -1,0 +1,45 @@
+
+# Adaptation of ruoso++'s Grammar::EBNF slang code to Grammar::BNF
+
+use Grammar::BNF;
+use nqp;
+use QAST:from<NQP>;
+sub EXPORT(|) {
+    my sub lk(Mu \h, \k) {
+        nqp::atkey(nqp::findmethod(h, 'hash')(h), k)
+    }
+    role Slang::BNF {
+        rule package_declarator:sym<bnf-grammar> {
+            <sym>
+            :my $*name;
+            <longname> { $*name := lk($/,'longname').Str }
+            \{
+            <rules=.FOREIGN_LANG('Grammar::BNF', 'main_syntax')>
+            \}
+        }
+    }
+    role Slang::BNF::Actions {
+        method package_declarator:sym<bnf-grammar>(Mu $/ is rw) {
+            # Bits extracted from rakudo/src/Perl6/Grammar.nqp (package_def)
+            my $longname := $*W.dissect_longname(lk($/,'longname'));
+            my $outer := $*W.cur_lexpad();
+            # Locate any existing symbol. Note that it's only a match
+            # with "my" if we already have a declaration in this scope.
+            my $exists := 0;
+            my @name = $longname.type_name_parts('package name', :decl(1));
+            my $target_package :=
+                $longname && $longname.is_declared_in_global()
+                ?? $*GLOBALish
+                !! $*OUTERPACKAGE;
+            my $*PACKAGE = lk($/,"rules").made();
+            $*W.install_package($/, @name, 'our', 'bnf-grammar',
+                                $target_package, $outer, $*PACKAGE);
+            $/.'make'(QAST::IVal.new(:value(1)));
+        }
+    }
+    nqp::bindkey(%*LANG, 'MAIN', %*LANG<MAIN>.HOW.mixin(%*LANG<MAIN>, Slang::BNF));
+    nqp::bindkey(%*LANG, 'MAIN-actions', %*LANG<MAIN-actions>.HOW.mixin(%*LANG<MAIN-actions>, Slang::BNF::Actions));
+    nqp::bindkey(%*LANG, 'Grammar::BNF', Grammar::BNF);
+    nqp::bindkey(%*LANG, 'Grammar::BNF-actions', Grammar::BNF-actions);
+    {}
+}


### PR DESCRIPTION
This only does slang for BNF, not the ABNF in the other PR yet.
