### PR TITLE
Fix for current rakudo

### DIFF
--- a/lib/Slang/ABNF.pm
+++ b/lib/Slang/ABNF.pm
@@ -22,7 +22,7 @@ sub EXPORT(|) {
         }
     }
     role Slang::ABNF::Actions {
-        method package_declarator:sym<abnf-grammar>(Mu $/ is rw) {
+        method package_declarator:sym<abnf-grammar>(Mu $/) {
             # Bits extracted from rakudo/src/Perl6/Grammar.nqp (package_def)
             my $longname := $*W.dissect_longname(lk($/,'longname'));
             my $outer := $*W.cur_lexpad();

--- a/lib/Slang/BNF.pm
+++ b/lib/Slang/BNF.pm
@@ -19,7 +19,7 @@ sub EXPORT(|) {
         }
     }
     role Slang::BNF::Actions {
-        method package_declarator:sym<bnf-grammar>(Mu $/ is rw) {
+        method package_declarator:sym<bnf-grammar>(Mu $/) {
             # Bits extracted from rakudo/src/Perl6/Grammar.nqp (package_def)
             my $longname := $*W.dissect_longname(lk($/,'longname'));
             my $outer := $*W.cur_lexpad();

--- a/t/abnf.t
+++ b/t/abnf.t
@@ -398,4 +398,3 @@ foo = "bar"
 
 ok(A::C.parse("bar"), "Parse succeeds");
 ok(!A::C.parse("far"), "Parse fails when it doesn't match");
-done();


### PR DESCRIPTION
- remove two "is rw" that were unnecessary, and produce exceptions
  with the current, stricter checking
- remove a done() from a test which has a test plan anyway
