### PR TITLE
Define slang

### DIFF
--- a/lib/Slang/ABNF.pm
+++ b/lib/Slang/ABNF.pm
@@ -41,13 +41,25 @@ sub EXPORT(|) {
 
         }
     }
-    nqp::bindkey(%*LANG, 'MAIN',
-                 %*LANG<MAIN>.HOW.mixin(%*LANG<MAIN>, Slang::ABNF));
-    nqp::bindkey(%*LANG, 'MAIN-actions',
-                 %*LANG<MAIN-actions>.HOW.mixin(%*LANG<MAIN-actions>,
-                                                Slang::ABNF::Actions));
-    nqp::bindkey(%*LANG, 'Grammar::ABNF::Slang', Grammar::ABNF::Slang);
-    nqp::bindkey(%*LANG, 'Grammar::ABNF::Slang-actions',
-                 Grammar::ABNF::Slang-actions);
+
+    my Mu $MAIN-grammar := nqp::atkey(%*LANG, 'MAIN');
+    my $grammar := $MAIN-grammar.^mixin(Slang::ABNF);
+    my Mu $MAIN-actions := nqp::atkey(%*LANG, 'MAIN-actions');
+    my $actions := $MAIN-actions.^mixin(Slang::ABNF::Actions);
+
+    # old way
+    try {
+        nqp::bindkey(%*LANG, 'MAIN', $grammar);
+        nqp::bindkey(%*LANG, 'MAIN-actions', $actions);
+        nqp::bindkey(%*LANG, 'Grammar::ABNF::Slang',
+                     Grammar::ABNF::Slang);
+        nqp::bindkey(%*LANG, 'Grammar::ABNF::Slang-actions',
+                     Grammar::ABNF::Slang-actions);
+    }
+    # new way
+    try {
+        $*LANG.define_slang("MAIN", $grammar, $actions);
+        $*LANG.define_slang("Grammar::ABNF::Slang", Grammar::ABNF::Slang, Grammar::ABNF::Slang-actions );
+    }
     {}
 }

--- a/lib/Slang/ABNF.pm
+++ b/lib/Slang/ABNF.pm
@@ -10,6 +10,7 @@ sub EXPORT(|) {
     }
     role Slang::ABNF {
         rule package_declarator:sym<abnf-grammar> {
+            :my $*OUTERPACKAGE := self.package;
             <sym>
             :my $*name;
 	    :my %*rules;

--- a/lib/Slang/BNF.pm
+++ b/lib/Slang/BNF.pm
@@ -37,9 +37,23 @@ sub EXPORT(|) {
             $/.'make'(QAST::IVal.new(:value(1)));
         }
     }
-    nqp::bindkey(%*LANG, 'MAIN', %*LANG<MAIN>.HOW.mixin(%*LANG<MAIN>, Slang::BNF));
-    nqp::bindkey(%*LANG, 'MAIN-actions', %*LANG<MAIN-actions>.HOW.mixin(%*LANG<MAIN-actions>, Slang::BNF::Actions));
-    nqp::bindkey(%*LANG, 'Grammar::BNF', Grammar::BNF);
-    nqp::bindkey(%*LANG, 'Grammar::BNF-actions', Grammar::BNF-actions);
+
+    my Mu $MAIN-grammar := nqp::atkey(%*LANG, 'MAIN');
+    my $grammar := $MAIN-grammar.^mixin(Slang::BNF);
+    my Mu $MAIN-actions := nqp::atkey(%*LANG, 'MAIN-actions');
+    my $actions := $MAIN-actions.^mixin(Slang::BNF::Actions);
+
+    # old way
+    try {
+        nqp::bindkey(%*LANG, 'MAIN', $grammar);
+        nqp::bindkey(%*LANG, 'MAIN-actions', $actions);
+        nqp::bindkey(%*LANG, 'Grammar::BNF', Grammar::BNF);
+        nqp::bindkey(%*LANG, 'Grammar::BNF-actions', Grammar::BNF-actions);
+    }
+    # new way
+    try {
+        $*LANG.define_slang("MAIN", $grammar, $actions);
+        $*LANG.define_slang("Grammar::BNF", Grammar::BNF, Grammar::BNF-actions);
+    }
     {}
 }

--- a/lib/Slang/BNF.pm
+++ b/lib/Slang/BNF.pm
@@ -16,6 +16,7 @@ sub EXPORT(|) {
             \{
             <rules=.FOREIGN_LANG('Grammar::BNF', 'main_syntax')>
             \}
+            <.set_braid_from(self)>
         }
     }
     role Slang::BNF::Actions {

--- a/lib/Slang/BNF.pm
+++ b/lib/Slang/BNF.pm
@@ -10,6 +10,7 @@ sub EXPORT(|) {
     }
     role Slang::BNF {
         rule package_declarator:sym<bnf-grammar> {
+            :my $*OUTERPACKAGE := self.package;
             <sym>
             :my $*name;
             <longname> { $*name := lk($/,'longname').Str }


### PR DESCRIPTION
Adjust to new define_slang metaprogramming interface.  Upstream fixes to rakudo and
nqp (already merges) are also part of restoring this module to working order.
