### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -3,6 +3,7 @@
   "name" : "Grammar::BNF",
   "description" : "Parse BNF and ABNF grammars and generate Perl 6 grammars from them",
   "version" : "v0.1.0",
+  "license" : "MIT",
   "build-depends" : [ ],
   "test-depends" : [
     "Test"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license